### PR TITLE
Remove upper bounds on dependencies

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -37,6 +37,7 @@ let parse_test_case_json s =
   | `Assoc [("test_cases", `List seq)] -> List.map seq ~f:(function
     | `Assoc assoc -> List.Assoc.map assoc ~f:(function 
       | `String v -> v
+      | `Null -> ""
       | _ -> failwith "bad test case json")
     | _ -> failwith "bad test case json")
   | _ -> failwith "bad test case json"

--- a/user-agent-parser.opam
+++ b/user-agent-parser.opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_deriving" {build}
   "ppx_let" {build}
   "stdio" {>= "v0.11"}
-  "re" {>= "1.8.0" & < "2.0.0"}
+  "re" {>= "1.8.0"}
   "yaml" {build & >= "0.2.1"}
   "yojson" {>= "1.6.0"}
 ]

--- a/user-agent-parser.opam
+++ b/user-agent-parser.opam
@@ -9,15 +9,15 @@ bug-reports: "https://github.com/issuu/uap-ocaml/issues"
 build: [["dune" "build" "-p" name "-j" jobs]]
 run-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depends: [
-  "alcotest" {with-test & >= "0.8.3" & < "0.9.0"}
+  "alcotest" {with-test & >= "0.8.3"}
   "base" {>= "v0.11"}
-  "dune" {build}
+  "dune"
   "ppx_deriving" {build}
   "ppx_let" {build}
   "stdio" {>= "v0.11"}
   "re" {>= "1.8.0" & < "2.0.0"}
-  "yaml" {build & >= "0.2.1" & < "0.3.0"}
-  "yojson" {>= "1.6.0" & < "2.0"}
+  "yaml" {build & >= "0.2.1"}
+  "yojson" {>= "1.6.0"}
 ]
 description: """
 OCaml implementation of the user agent parse rules from https://github.com/ua-parser/uap-core"""


### PR DESCRIPTION
I'm doing this in order to enable `bigpingback` to use newer libraries.